### PR TITLE
Fix Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,6 @@ jobs:
         # create gate based on the "Sonar way" gate
         - curl -X POST -u "$TOKEN:" 'http://localhost:9000/api/qualitygates/copy?id=1&name=test-gate'
         # run with base gate which will pass
-        - ls -latr ../build/libs
         - ./gradlew applyQualityGate sonarqube verifySonarqubeQualityGates -Dsonar.host.url=http://localhost:9000 -Dsonar.login=$TOKEN
         # apply more strict rules to gate
         - curl -X POST -u "$TOKEN:" 'http://localhost:9000/api/qualitygates/create_condition?gateId=2&metric=vulnerabilities&op=GT&error=0'

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,12 +62,3 @@ deploy:
   local-dir: docs
   on:
     branch: master
-
-
-# setup gate
-# spin up docker image
-# get user token
-# copy existing gate
-# curl -X POST 'http://localhost:9000/api/qualitygates/copy?id=1&name=test-gate'
-# curl -X POST 'http://localhost:9000/api/qualitygates/create_condition?gateId=2&metric=vulnerabilities&op=GT&error=0' \
-# ./gradlew applyQualityGate sonarqube verifySonarqubeQualityGates -Dsonar.host.url=http://localhost:9000  -Dsonar.login=<token>

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ jobs:
         # create gate based on the "Sonar way" gate
         - curl -X POST -u "$TOKEN:" 'http://localhost:9000/api/qualitygates/copy?id=1&name=test-gate'
         # run with base gate which will pass
+        - ls -latr ../build/libs
         - ./gradlew applyQualityGate sonarqube verifySonarqubeQualityGates -Dsonar.host.url=http://localhost:9000 -Dsonar.login=$TOKEN
         # apply more strict rules to gate
         - curl -X POST -u "$TOKEN:" 'http://localhost:9000/api/qualitygates/create_condition?gateId=2&metric=vulnerabilities&op=GT&error=0'

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ If the project does not already exist within SonarQube, it will be created.
 buildscript {
   dependencies {
     classpath "org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:2.2.1"
-    classpath "com.usaa.plugin.gradle:sonarqube-quality-gates:1.0"
+    classpath "com.usaa.plugin.gradle:sonarqube-quality-gates:3.0.0"
   }
 }
 apply plugin: 'org.sonarqube'

--- a/test-project/build.gradle
+++ b/test-project/build.gradle
@@ -7,7 +7,7 @@ buildscript{
 	}
     dependencies {
 		classpath 'org.codehaus.groovy.modules.http-builder:http-builder:0.7.1'
-		classpath 'com.usaa.plugin.gradle:sonar-quality-gates-plugin:3.0.0-SNAPSHOT'
+		classpath 'com.usaa.plugin.gradle:sonar-quality-gates-plugin:3.+'
     }
 }
 


### PR DESCRIPTION
Issue was that when the repo is tagged, gradle generates a jar without the `-SNAPSHOT` qualifier which was specified as required within the test project. Making the version number a wildcard, it resolves this issue for both dev and tagged builds.